### PR TITLE
Prepare common data model 0.4

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -17,7 +17,7 @@ Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 
 [compat]
 CFTime = "0.1.1, 0.2"
-CommonDataModel = "0.3.4"
+CommonDataModel = "0.4"
 DataStructures = "0.17, 0.18"
 DiskArrays = "0.4.5"
 NetCDF_jll = "=400.701.400, =400.702.400, =400.902.5, =400.902.208, =400.902.209, =400.902.211, =401.900.300"

--- a/Project.toml
+++ b/Project.toml
@@ -17,7 +17,7 @@ Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 
 [compat]
 CFTime = "0.1.1, 0.2"
-CommonDataModel = "0.4"
+CommonDataModel = "0.3.4"
 DataStructures = "0.17, 0.18"
 DiskArrays = "0.4.5"
 NetCDF_jll = "=400.701.400, =400.702.400, =400.902.5, =400.902.208, =400.902.209, =400.902.211, =401.900.300"

--- a/src/NCDatasets.jl
+++ b/src/NCDatasets.jl
@@ -41,7 +41,7 @@ import CommonDataModel: AbstractDataset, AbstractVariable,
     varbyattrib, CFStdName, @CF_str, ancillaryvariables, filter, coord, bounds,
     MFDataset, MFCFVariable,
     DeferDataset, metadata, Resource,
-    SubDataset, SubVariable, subsub,
+    SubDataset, SubVariable,
     chunking, deflate, checksum, fillmode,
     iswritable, sync, CatArrays,
     SubDataset,
@@ -73,9 +73,6 @@ include("defer.jl")
 include("multifile.jl")
 include("ncgen.jl")
 include("precompile.jl")
-
-DiskArrays.@implement_diskarray NCDatasets.Variable
-
 
 export CatArrays
 export CFTime

--- a/test/test_subvariable.jl
+++ b/test/test_subvariable.jl
@@ -1,25 +1,10 @@
 
 using NCDatasets
-using NCDatasets: subsub, SubDataset
+using NCDatasets: SubDataset
 using DataStructures
 using Test
-
-@test subsub((1:10,),(2:10,)) == (2:10,)
-@test subsub((2:10,),(2:9,)) == (3:10,)
-@test subsub((2:2:10,),(2:3,)) == (4:2:6,)
-@test subsub((:,),(2:4,)) == (2:4,)
-@test subsub((2:2:10,),(3,)) == (6,)
-@test subsub((2:2:10,:),(2:3,2:4)) == (4:2:6,2:4)
-@test subsub((2:2:10,:),(2:3,2)) == (4:2:6,2)
-@test subsub((1,:),(2:3,)) == (1,2:3)
-@test subsub((1,:),(1,)) == (1,1)
-
-A = rand(10,10)
-ip = (2:2:10,:)
-i = (2:3,2:4)
-j = subsub(ip,i)
-A[ip...][i...] == A[j...]
-
+import CommonDataModel
+import DiskArrays
 
 
 fname = tempname()
@@ -89,6 +74,9 @@ ncvar_view = view(view(ncvar,:,1:2),1:2:6,:)
 
 @test data_view == Array(ncvar_view)
 @test data_view == ncvar_view
+
+@test ncvar_view isa CommonDataModel.SubVariable
+@test ncvar_view isa DiskArrays.AbstractSubDiskArray
 
 ind = CartesianIndex(1,1)
 @test ncvar_view[ind] == data_view[ind]

--- a/test/test_variable.jl
+++ b/test/test_variable.jl
@@ -3,6 +3,7 @@ using Dates
 using Printf
 using NCDatasets
 using DataStructures
+import DiskArrays
 
 sz = (4,5)
 filename = tempname()
@@ -10,6 +11,8 @@ filename = tempname()
 #if isfile(filename)
 #    rm(filename)
 #end
+
+@test NCDatasets.Variable <: DiskArrays.AbstractDiskArray
 
 # The mode "c" stands for creating a new file (clobber)
 NCDataset(filename,"c") do ds


### PR DESCRIPTION
This PR requires: https://github.com/JuliaGeo/CommonDataModel.jl/pull/35

The PR is related to the following issues https://github.com/JuliaGeo/CommonDataModel.jl/issues/32 and https://github.com/JuliaGeo/NCDatasets.jl/issues/274

Content 
- Bump CommonDataModel to 0.4 (Not merged yet).
- Remove `DiskArrays.@implement_diskarray`. `Variable` is now a subtype of `AbstractDiskArray` so this is not needed anymore.
- Remove the custom code for `subsub` used for views. This is not needed anymore since the DiskArrays views are now used.